### PR TITLE
remove empty db

### DIFF
--- a/impactdb.v1.1.0.dg_filled.db
+++ b/impactdb.v1.1.0.dg_filled.db
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:35cfb2fe1cbc0c10ac66bc5bb5a253471c3bef205e2502ee394654527bacb31d
-size 122880


### PR DESCRIPTION
An empty database was accidentally left outside the releases directory. This PR removes it. No review required. 